### PR TITLE
Fix broken link to code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE-OF-CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 ## Adding an awesome bot
 


### PR DESCRIPTION
The `CONTRIBUTING.md` links to `CODE-OF-CONDUCT.md` instead of `CODE_OF_CONDUCT.md`.